### PR TITLE
USDA Food Search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,12 +17,13 @@ group :development, :test do
   gem 'pry'
   gem 'awesome_print'
   gem 'figaro'
-  gem 'vcr'
 end
 
 group :test do
   gem 'rspec-rails'
   gem 'capybara'
+  gem 'webmock'
+  gem 'vcr'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       xpath (~> 3.2)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.4)
     diff-lcs (1.3)
     erubi (1.8.0)
@@ -71,6 +73,7 @@ GEM
       thor (~> 0.14)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashdiff (0.4.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     jbuilder (2.9.1)
@@ -152,6 +155,7 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
     ruby_dep (1.5.0)
+    safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -183,6 +187,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webmock (3.6.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -210,6 +218,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   vcr
   web-console (>= 3.3.0)
+  webmock
 
 RUBY VERSION
    ruby 2.4.1p111

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -1,0 +1,4 @@
+class FoodsController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -1,4 +1,7 @@
 class FoodsController < ApplicationController
   def index
+    render locals: {
+      facade: FoodSearchFacade.new(params[:q])
+    }
   end
 end

--- a/app/facades/food_search_facade.rb
+++ b/app/facades/food_search_facade.rb
@@ -3,7 +3,7 @@ class FoodSearchFacade
 
   def initialize(query)
     @food_json = food_search(query)
-    @result_count = @food_json[:total]
+    @result_count = @food_json[:list][:total]
   end
 
   def food_search(query)
@@ -11,7 +11,7 @@ class FoodSearchFacade
   end
 
   def results
-    @food_json[:item].map do |food|
+    @food_json[:list][:item].map do |food|
       Food.new(food)
     end
   end

--- a/app/facades/food_search_facade.rb
+++ b/app/facades/food_search_facade.rb
@@ -1,0 +1,24 @@
+class FoodSearchFacade
+  attr_reader :result_count
+
+  def initialize(query)
+    @food_json = food_search(query)
+    @result_count = @food_json[:total]
+  end
+
+  def food_search(query)
+    food_service.search(query)
+  end
+
+  def results
+    @food_json[:item].map do |food|
+      Food.new(food)
+    end
+  end
+
+  private
+
+  def food_service
+    FoodService.new
+  end
+end

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -1,0 +1,5 @@
+class Food
+  def initialize(info)
+    
+  end
+end

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -1,5 +1,10 @@
 class Food
+  attr_reader :ndbno, :name, :group, :data_source, :manufacturer
   def initialize(info)
-    
+    @ndbno = info[:ndbno]
+    @name = info[:name]
+    @group = info[:group]
+    @data_source = info[:ds]
+    @manufacturer = info[:manu]
   end
 end

--- a/app/services/food_service.rb
+++ b/app/services/food_service.rb
@@ -1,0 +1,19 @@
+class FoodService
+  def search(query)
+    get_json('/ndb/search', {q: query, max: 10})
+  end
+
+  private
+
+  def get_json(url, params = {})
+    response = conn.get(url, params)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def conn
+    Faraday.new(url: 'https://api.nal.usda.gov') do |f|
+      f.params['api_key'] = ENV['gov-data-api-key']
+      f.adapter Faraday.default_adapter
+    end
+  end
+end

--- a/app/views/foods/index.html.erb
+++ b/app/views/foods/index.html.erb
@@ -1,0 +1,9 @@
+<h1>Search Results</h1>
+<p><%= facade.result_count %> results</p>
+
+<section id='search-results'>
+  <% facade.results.each do |food| %>
+    <div class="food-info">
+      <p>Placeholder Title</p>
+    </div>
+</section>

--- a/app/views/foods/index.html.erb
+++ b/app/views/foods/index.html.erb
@@ -4,7 +4,11 @@
 <section id='search-results'>
   <% facade.results.each do |food| %>
     <div class="food-info">
-      <p>Placeholder Title</p>
+      <p>NDB Number: <%= food.ndbno %></p>
+      <p>Name: <%= food.name %></p>
+      <p>Food Group: <%= food.group %></p>
+      <p>Data Source: <%= food.data_source %></p>
+      <p>Manufacturer: <%= food.manufacturer %></p>
     </div>
   <% end %>
 </section>

--- a/app/views/foods/index.html.erb
+++ b/app/views/foods/index.html.erb
@@ -1,5 +1,6 @@
 <h1>Search Results</h1>
 <p><%= facade.result_count %> results</p>
+<p>----------------------</p>
 
 <section id='search-results'>
   <% facade.results.each do |food| %>
@@ -9,6 +10,7 @@
       <p>Food Group: <%= food.group %></p>
       <p>Data Source: <%= food.data_source %></p>
       <p>Manufacturer: <%= food.manufacturer %></p>
+      <p>----------------------</p>
     </div>
   <% end %>
 </section>

--- a/app/views/foods/index.html.erb
+++ b/app/views/foods/index.html.erb
@@ -6,4 +6,5 @@
     <div class="food-info">
       <p>Placeholder Title</p>
     </div>
+  <% end %>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
   root "welcome#index"
+
+  get '/foods', to: "foods#index"
 end

--- a/fixtures/vcr_cassettes/sweet_potato_search.yml
+++ b/fixtures/vcr_cassettes/sweet_potato_search.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.nal.usda.gov/ndb/search?api_key=TbA6Jg3ZStFTEZJxTyo9HkPrhKjspJo0gmNbsUz4&max=10&q=sweet%20potatoes
+    uri: https://api.nal.usda.gov/ndb/search?api_key=<API-KEY>&max=10&q=sweet%20potatoes
     body:
       encoding: US-ASCII
       string: ''
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - openresty
       Date:
-      - Mon, 08 Jul 2019 16:40:30 GMT
+      - Mon, 08 Jul 2019 17:04:51 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -33,7 +33,7 @@ http_interactions:
       X-Ratelimit-Limit:
       - '3600'
       X-Ratelimit-Remaining:
-      - '3576'
+      - '3578'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Credentials:
@@ -149,5 +149,5 @@ http_interactions:
             }
         }
     http_version: 
-  recorded_at: Mon, 08 Jul 2019 16:40:30 GMT
+  recorded_at: Mon, 08 Jul 2019 17:04:51 GMT
 recorded_with: VCR 5.0.0

--- a/fixtures/vcr_cassettes/sweet_potato_search.yml
+++ b/fixtures/vcr_cassettes/sweet_potato_search.yml
@@ -1,0 +1,153 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.nal.usda.gov/ndb/search?api_key=TbA6Jg3ZStFTEZJxTyo9HkPrhKjspJo0gmNbsUz4&max=10&q=sweet%20potatoes
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - openresty
+      Date:
+      - Mon, 08 Jul 2019 16:40:30 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Limit:
+      - '3600'
+      X-Ratelimit-Remaining:
+      - '3576'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS
+      Access-Control-Allow-Headers:
+      - DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      - max-age=63072000; includeSubDomains; preload
+      Age:
+      - '0'
+      Via:
+      - https/1.1 api-umbrella (ApacheTrafficServer [cMsSf ])
+      X-Cache:
+      - MISS
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+            "list": {
+                "q": "sweet potatoes",
+                "sr": "1",
+                "ds": "any",
+                "start": 0,
+                "end": 10,
+                "total": 531,
+                "group": "",
+                "sort": "r",
+                "item": [
+                    {
+                        "offset": 0,
+                        "group": "Branded Food Products Database",
+                        "name": "ONE POTATO TWO POTATO, PLAIN JAYNES, SWEET POTATO CHIPS, UPC: 785654000544",
+                        "ndbno": "45094945",
+                        "ds": "LI",
+                        "manu": "Dieffenbach's Potato Chips"
+                    },
+                    {
+                        "offset": 1,
+                        "group": "Branded Food Products Database",
+                        "name": "TERRA, SWEET POTATO CHIPS, PUMPKIN SPICE SWEETS, UPC: 728229014751",
+                        "ndbno": "45165952",
+                        "ds": "LI",
+                        "manu": "THE HAIN CELESTIAL GROUP, INC."
+                    },
+                    {
+                        "offset": 2,
+                        "group": "Branded Food Products Database",
+                        "name": "CHILI'S, SWEET & SPICY CHICKEN & SWEET POTATOES, BIG BOLD, UPC: 717854470377",
+                        "ndbno": "45109414",
+                        "ds": "LI",
+                        "manu": "Bellisio Foods Inc"
+                    },
+                    {
+                        "offset": 3,
+                        "group": "Branded Food Products Database",
+                        "name": "SWEET POTATO POPPED POTATO CRISPS, UPC: 075450137415",
+                        "ndbno": "45219208",
+                        "ds": "LI",
+                        "manu": "Hy-Vee, Inc."
+                    },
+                    {
+                        "offset": 4,
+                        "group": "Branded Food Products Database",
+                        "name": "SWEET POTATO KETTLE POTATO CHIPS, UPC: 762111242839",
+                        "ndbno": "45324838",
+                        "ds": "LI",
+                        "manu": "STARBUCKS COFFEE COMPANY"
+                    },
+                    {
+                        "offset": 5,
+                        "group": "Branded Food Products Database",
+                        "name": "SWEET POTATOES, RED POTATOES, CARROTS & PARSNIPS VEGETABLES FOR ROASTING, UPC: 070560970907",
+                        "ndbno": "45372027",
+                        "ds": "LI",
+                        "manu": "The Pictsweet Company"
+                    },
+                    {
+                        "offset": 6,
+                        "group": "Vegetables and Vegetable Products",
+                        "name": "Sweet potato leaves, raw",
+                        "ndbno": "11505",
+                        "ds": "SR",
+                        "manu": "none"
+                    },
+                    {
+                        "offset": 7,
+                        "group": "Vegetables and Vegetable Products",
+                        "name": "Sweet potato, raw, unprepared (Includes foods for USDA's Food Distribution Program)",
+                        "ndbno": "11507",
+                        "ds": "SR",
+                        "manu": "none"
+                    },
+                    {
+                        "offset": 8,
+                        "group": "Vegetables and Vegetable Products",
+                        "name": "Sweet potato, canned, mashed",
+                        "ndbno": "11514",
+                        "ds": "SR",
+                        "manu": "none"
+                    },
+                    {
+                        "offset": 9,
+                        "group": "Vegetables and Vegetable Products",
+                        "name": "Sweet potato, frozen, unprepared (Includes foods for USDA's Food Distribution Program)",
+                        "ndbno": "11516",
+                        "ds": "SR",
+                        "manu": "none"
+                    }
+                ]
+            }
+        }
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 16:40:30 GMT
+recorded_with: VCR 5.0.0

--- a/spec/features/search/user_can_search_with_form_spec.rb
+++ b/spec/features/search/user_can_search_with_form_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe 'As a user', type: :feature do
       # And I fill in the search form with "sweet potatoes"
       fill_in 'q', with: 'sweet potatoes'
       # And I click "Search"
-      click_on 'Search'
+      VCR.use_cassette('sweet_potato_search') do
+        click_on 'Search'
+      end
       # Then I should be on page "/foods"
       expect(current_path).to eq(foods_path)
       # Then I should see a total of the number of items returned by the search. (531 for sweet potatoes)
@@ -103,7 +105,9 @@ RSpec.describe 'As a user', type: :feature do
         ]
       visit root_path
       fill_in 'q', with: 'sweet potatoes'
-      click_on 'Search'
+      VCR.use_cassette('sweet_potato_search') do
+        click_on 'Search'
+      end
 
       foods = page.all('.food-info')
       foods.each_with_index do |food, index|

--- a/spec/features/search/user_can_search_with_form_spec.rb
+++ b/spec/features/search/user_can_search_with_form_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe 'As a user', type: :feature do
       # Then I should see a total of the number of items returned by the search. (531 for sweet potatoes)
       expect(page).to have_content('531 results')
       # Then I should see a list of ten foods sorted by relevance.
-      expect(page).to have_content('Sweet Potato Things')
+      within("#search-results") do
+        expect(page).to have_selector(".food-info", count: 10)
+      end
     end
   end
 end

--- a/spec/features/search/user_can_search_with_form_spec.rb
+++ b/spec/features/search/user_can_search_with_form_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe 'As a user', type: :feature do
+  context 'When I visit the root path' do
+    it 'I can use the search form' do
+      visit root_path
+      # And I fill in the search form with "sweet potatoes"
+      fill_in 'q', with: 'sweet potatoes'
+      # And I click "Search"
+      click_on 'Search'
+      # Then I should be on page "/foods"
+      expect(current_path).to eq(foods_path)
+      # Then I should see a total of the number of items returned by the search. (531 for sweet potatoes)
+      expect(page).to have_content('531 results')
+      # Then I should see a list of ten foods sorted by relevance.
+      expect(page).to have_content('Sweet Potato Things')
+    end
+  end
+end

--- a/spec/features/search/user_can_search_with_form_spec.rb
+++ b/spec/features/search/user_can_search_with_form_spec.rb
@@ -14,7 +14,111 @@ RSpec.describe 'As a user', type: :feature do
       expect(page).to have_content('531 results')
       # Then I should see a list of ten foods sorted by relevance.
       within("#search-results") do
-        expect(page).to have_selector(".food-info", count: 10)
+        expect(page).to have_selector('.food-info', count: 10)
+      end
+    end
+
+    it 'returns each foods information' do
+      sweet_potatoes = [
+            {
+                "offset": 0,
+                "group": "Branded Food Products Database",
+                "name": "ONE POTATO TWO POTATO, PLAIN JAYNES, SWEET POTATO CHIPS, UPC: 785654000544",
+                "ndbno": "45094945",
+                "ds": "LI",
+                "manu": "Dieffenbach's Potato Chips"
+            },
+            {
+                "offset": 1,
+                "group": "Branded Food Products Database",
+                "name": "TERRA, SWEET POTATO CHIPS, PUMPKIN SPICE SWEETS, UPC: 728229014751",
+                "ndbno": "45165952",
+                "ds": "LI",
+                "manu": "THE HAIN CELESTIAL GROUP, INC."
+            },
+            {
+                "offset": 2,
+                "group": "Branded Food Products Database",
+                "name": "CHILI'S, SWEET & SPICY CHICKEN & SWEET POTATOES, BIG BOLD, UPC: 717854470377",
+                "ndbno": "45109414",
+                "ds": "LI",
+                "manu": "Bellisio Foods Inc"
+            },
+            {
+                "offset": 3,
+                "group": "Branded Food Products Database",
+                "name": "SWEET POTATO POPPED POTATO CRISPS, UPC: 075450137415",
+                "ndbno": "45219208",
+                "ds": "LI",
+                "manu": "Hy-Vee, Inc."
+            },
+            {
+                "offset": 4,
+                "group": "Branded Food Products Database",
+                "name": "SWEET POTATO KETTLE POTATO CHIPS, UPC: 762111242839",
+                "ndbno": "45324838",
+                "ds": "LI",
+                "manu": "STARBUCKS COFFEE COMPANY"
+            },
+            {
+                "offset": 5,
+                "group": "Branded Food Products Database",
+                "name": "SWEET POTATOES, RED POTATOES, CARROTS & PARSNIPS VEGETABLES FOR ROASTING, UPC: 070560970907",
+                "ndbno": "45372027",
+                "ds": "LI",
+                "manu": "The Pictsweet Company"
+            },
+            {
+                "offset": 6,
+                "group": "Vegetables and Vegetable Products",
+                "name": "Sweet potato leaves, raw",
+                "ndbno": "11505",
+                "ds": "SR",
+                "manu": "none"
+            },
+            {
+                "offset": 7,
+                "group": "Vegetables and Vegetable Products",
+                "name": "Sweet potato, raw, unprepared (Includes foods for USDA's Food Distribution Program)",
+                "ndbno": "11507",
+                "ds": "SR",
+                "manu": "none"
+            },
+            {
+                "offset": 8,
+                "group": "Vegetables and Vegetable Products",
+                "name": "Sweet potato, canned, mashed",
+                "ndbno": "11514",
+                "ds": "SR",
+                "manu": "none"
+            },
+            {
+                "offset": 9,
+                "group": "Vegetables and Vegetable Products",
+                "name": "Sweet potato, frozen, unprepared (Includes foods for USDA's Food Distribution Program)",
+                "ndbno": "11516",
+                "ds": "SR",
+                "manu": "none"
+            }
+        ]
+      visit root_path
+      fill_in 'q', with: 'sweet potatoes'
+      click_on 'Search'
+
+      foods = page.all('.food-info')
+      foods.each_with_index do |food, index|
+        within(food) do
+          # - The food's NDB Number
+          expect(page).to have_content("NDB Number: #{sweet_potatoes[index]['ndbno']}")
+          # - The food's name
+          expect(page).to have_content("Name: #{sweet_potatoes[index]['name']}")
+          # - The food group to which the food belongs
+          expect(page).to have_content("Food Group: #{sweet_potatoes[index]['group']}")
+          # - The food's data source
+          expect(page).to have_content("Data Source: #{sweet_potatoes[index]['ds']}")
+          # - The food's manufacturer
+          expect(page).to have_content("Manufacturer: #{sweet_potatoes[index]['manu']}")
+        end
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,7 @@ require 'vcr'
 VCR.configure do |config|
   config.cassette_library_dir = "fixtures/vcr_cassettes"
   config.hook_into :webmock
+  config.filter_sensitive_data('<API-KEY>') { ENV['gov-data-api-key'] }
 end
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,13 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'rspec/rails'
+require 'vcr'
+
+VCR.configure do |config|
+  config.cassette_library_dir = "fixtures/vcr_cassettes"
+  config.hook_into :webmock
+end
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
This PR brings in the functionality for a user to search through the USDA NDB for Food Information using a search form.
On the root path, there is a search form. Entering a term into this form and pressing Search will send a request to the USDAs API with that term, and limiting the results to the 10 most relevant.
The user is then redirected to a `/foods` page where they are provided the information on each of the 10 food items. They are also given the Total results count if we were not limiting our requests to 10. Fortunately for us, the API provides that number regardless of the limited number of items we request.